### PR TITLE
Fix SRT formatted output

### DIFF
--- a/subtitle-overlap-fixer.go
+++ b/subtitle-overlap-fixer.go
@@ -80,7 +80,7 @@ func writeOneSubtitle(file io.Writer, subtitle *Subtitle, idx *int) error {
 	_, err := fmt.Fprint(file,
 		*idx, "\n",
 		printDuration(subtitle.fromTime), " --> ", printDuration(subtitle.toTime), "\n",
-		subtitle.text, "\n\n")
+			     strings.TrimSpace(subtitle.text), "\n\n")
 	*idx++
 	return err
 }


### PR DESCRIPTION
In some combining cases, `subtitle.text` contains line breaks at the beginning, breaking SRT formatting.

See [subs.txt](https://github.com/bleggett/subtitle-overlap-fixer/files/9577445/subs.txt)
